### PR TITLE
Update Token Instructions

### DIFF
--- a/TwitchChatIntegration/ModConfig.cs
+++ b/TwitchChatIntegration/ModConfig.cs
@@ -20,8 +20,7 @@ namespace TwitchChatIntegration
 
             return FieldValid.Invoke(this.Username) && 
                 FieldValid.Invoke(this.Password) && 
-                FieldValid.Invoke(this.TargetChannel) &&
-                this.Password.Contains("oauth:");
+                FieldValid.Invoke(this.TargetChannel);
         }
     }
 }

--- a/TwitchChatIntegration/README.md
+++ b/TwitchChatIntegration/README.md
@@ -7,7 +7,7 @@ In multiplayer, the Twitch messages will only be sent to the chat of the mod use
 
 ## Usage
 You will need to provide a Twitch account that the chat bot can use, you can use the one you use to stream or a separate one.
-To log in the bot needs a user name and an OAuth token, which you can create here: https://twitchapps.com/tmi/.
+To log in the bot needs a user name and an OAuth token, which you can create here: [https://twitchtokengenerator.com/](https://twitchtokengenerator.com/) choose the "Bot Chat Token" option.
 Then you need to fill in this information along with the name of the channel you want to read the chat from into the file ``config.json``
 inside of the mod folder that is created when first starting the game with this mod installed.
 

--- a/TwitchChatIntegration/README.md
+++ b/TwitchChatIntegration/README.md
@@ -13,7 +13,7 @@ You will need to provide a Twitch account that the chat bot can use, you can use
 * Go through the login process and fill out the Captcha
 * In the `Generated Tokens` section, copy the `ACCESS TOKEN` value.
 * If not using GMCM, run the game once to generate the `config.json` file. Once the file is made, open it in a text editor and fill out the `Username` and `Password` (Use the `ACCESS TOKEN` you generated in the last step) sections.
-* Make sure to also fill out the `TargetChannel` section too.
+* Make sure to also fill out the `TargetChannel` section with the channel you want to inspect (usually your own channel).
 
 ## Acknowledgements
 

--- a/TwitchChatIntegration/README.md
+++ b/TwitchChatIntegration/README.md
@@ -7,9 +7,13 @@ In multiplayer, the Twitch messages will only be sent to the chat of the mod use
 
 ## Usage
 You will need to provide a Twitch account that the chat bot can use, you can use the one you use to stream or a separate one.
-To log in the bot needs a user name and an OAuth token, which you can create here: [https://twitchtokengenerator.com/](https://twitchtokengenerator.com/) choose the "Bot Chat Token" option.
-Then you need to fill in this information along with the name of the channel you want to read the chat from into the file ``config.json``
-inside of the mod folder that is created when first starting the game with this mod installed.
+
+### To Login:
+* Create a "Bot Chat Token" from here: [https://twitchtokengenerator.com/](https://twitchtokengenerator.com/) choose the "Bot Chat Token" option.
+* Go through the login process and fill out the Captcha
+* In the `Generated Tokens` section, copy the `ACCESS TOKEN` value.
+* If not using GMCM, run the game once to generate the `config.json` file. Once the file is made, open it in a text editor and fill out the `Username` and `Password` (Use the `ACCESS TOKEN` you generated in the last step) sections.
+* Make sure to also fill out the `TargetChannel` section too.
 
 ## Acknowledgements
 

--- a/TwitchChatIntegration/TwitchBot.cs
+++ b/TwitchChatIntegration/TwitchBot.cs
@@ -77,7 +77,7 @@ namespace TwitchChatIntegration
             await streamWriter.WriteLineAsync("CAP REQ :twitch.tv/commands twitch.tv/tags");
 
             // Login
-            string formattedPass = password.remove('oauth:', string.Empty);
+            string formattedPass = password.Replace("oauth:", string.Empty);
             await streamWriter.WriteLineAsync($"PASS oauth:{formattedPass}");
             await streamWriter.WriteLineAsync($"NICK {username}");
             connected.SetResult(0);

--- a/TwitchChatIntegration/TwitchBot.cs
+++ b/TwitchChatIntegration/TwitchBot.cs
@@ -77,7 +77,8 @@ namespace TwitchChatIntegration
             await streamWriter.WriteLineAsync("CAP REQ :twitch.tv/commands twitch.tv/tags");
 
             // Login
-            await streamWriter.WriteLineAsync($"PASS {password}");
+            string formattedPass = password.remove('oauth:', string.Empty);
+            await streamWriter.WriteLineAsync($"PASS oauth:{formattedPass}");
             await streamWriter.WriteLineAsync($"NICK {username}");
             connected.SetResult(0);
 

--- a/TwitchChatIntegration/i18n/default.json
+++ b/TwitchChatIntegration/i18n/default.json
@@ -25,7 +25,7 @@
 	"config.twitch.behavior.filteredusers.tooltip": "Comma separated list of account names to ignore from the chat",
 
 	"config.twitch.password.title": "Twitch OAuth Password",
-	"config.twitch.password.info": "NOTE: this must be the full chat token including the oauth: prefix",
+	"config.twitch.password.info": "Generate a Bot Chat Token from twitchtokengenerator.com and paste it here",
 
 	"config.twitch.password.password": "Chat Password",
 	"config.twitch.password.password.tooltip": "This is the account password for the twitch account set as the username",


### PR DESCRIPTION
The old website for generating tokens no longer exists. I've went ahead and just updated the information and removed the necessity of adding the `oauth:` prefix as the website doesn't output the authorization tokens in that format automatically.